### PR TITLE
index moved to global level + gpu index

### DIFF
--- a/text_parser/test.ipynb
+++ b/text_parser/test.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "id": "3b0fd27a-2c64-48ad-9b25-370c02d4bc21",
    "metadata": {
     "scrolled": true
@@ -351,8 +351,8 @@
     "\n",
     "class CrossEncoderRanker(DocsRanker):\n",
     "    def __init__(self) -> None:\n",
-    "        # self.reranker_model = CrossEncoder('DiTy/cross-encoder-russian-msmarco', max_length=512, device='cuda')\n",
-    "        self.reranker_model = CrossEncoder('DiTy/cross-encoder-russian-msmarco', max_length=512, device='cpu')\n",
+    "        self.reranker_model = CrossEncoder('DiTy/cross-encoder-russian-msmarco', max_length=512, device='cuda')\n",
+    "        # self.reranker_model = CrossEncoder('DiTy/cross-encoder-russian-msmarco', max_length=512, device='cpu')\n",
     "\n",
     "    def rankDocuments(self, query, docs):\n",
     "        return np.array([self.reranker_model.predict([[query, doc]])[0] for doc in docs])\n",
@@ -361,7 +361,6 @@
     "import pymorphy2\n",
     "\n",
     "def findVectorsIndexes(query, encoder, kDocuments):\n",
-    "  index = getVectorDB(vectorDBPath)\n",
     "  queryEmbd = encoder.encode(query, normalize_embeddings=True)\n",
     "  D, I = index.search(np.array([queryEmbd]), kDocuments)\n",
     "  return I[0]\n",
@@ -394,6 +393,21 @@
    "outputs": [],
    "source": [
     "import time"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f6f5ecc2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "use_gpu_index = True\n",
+    "  \n",
+    "res = faiss.StandardGpuResources()\n",
+    "index = getVectorDB(vectorDBPath)\n",
+    "if use_gpu_index:\n",
+    "    index = faiss.index_cpu_to_gpu(res, 0, index)"
    ]
   },
   {


### PR DESCRIPTION
cross encoder перевел на инференс на гпу
убрал чтение индекса с диска при каждом поиске + добавил gpu index
[test-global-gpu-index.txt](https://github.com/user-attachments/files/17980354/test-global-gpu-index.txt)
[test-global-index.txt](https://github.com/user-attachments/files/17980355/test-global-index.txt)
[test-before.txt](https://github.com/user-attachments/files/17980356/test-before.txt)
тут в файлах результаты прогона теста, везде использовался инференс cross encoder на гпу
гпу индекс дает небольшое ускорение, но бОльшую часть дал перевод cross encoder на гпу
